### PR TITLE
Add unconfined option

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,8 @@ services:
       VALIDATORS_GRAFFITI: validating_from_DAppNode
       EXTRA_OPTS: ""
     image: "teku.obol-distributed-validator-goerli.dnp.dappnode.eth:0.1.0"
+    security_opt:
+      - "seccomp:unconfined"
 volumes:
   charon-data: {}
   teku-prater-data: {}


### PR DESCRIPTION
In old docker versions, Teku validator service is throwing: 
```
ERROR: JAVA_HOME is set to an invalid directory: /opt/java/openjdk
Please set the JAVA_HOME variable in your environment to match the
location of your Java installation.
```