### PR TITLE
Bump Lodestar to v1.15.1

### DIFF
--- a/charon-validator/Dockerfile.lodestar
+++ b/charon-validator/Dockerfile.lodestar
@@ -8,10 +8,10 @@ RUN apt update && apt install -y git g++ make python3
 
 RUN git clone https://github.com/ChainSafe/lodestar
 
-ARG LODESTAR_VERSION
+ARG VALIDATOR_CLIENT_VERSION
 
 RUN cd ./lodestar && \
-    git checkout ${LODESTAR_VERSION} && \
+    git checkout ${VALIDATOR_CLIENT_VERSION} && \
     yarn install --non-interactive --frozen-lockfile && \
     yarn build && \
     yarn install --non-interactive --frozen-lockfile --production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,10 @@ services:
   charon-validator-1:
     build:
       context: charon-validator
-      dockerfile: Dockerfile.teku
+      dockerfile: Dockerfile.lodestar
       args:
         UPSTREAM_VERSION: v0.17.2
-        VALIDATOR_CLIENT_VERSION: 23.11.0
+        VALIDATOR_CLIENT_VERSION: v1.15.1
         CLUSTER_ID: 1
     restart: on-failure
     volumes:
@@ -36,10 +36,10 @@ services:
   charon-validator-2:
     build:
       context: charon-validator
-      dockerfile: Dockerfile.teku
+      dockerfile: Dockerfile.lodestar
       args:
         UPSTREAM_VERSION: v0.17.2
-        VALIDATOR_CLIENT_VERSION: 23.11.0
+        VALIDATOR_CLIENT_VERSION: v1.15.1
         CLUSTER_ID: 2
     restart: on-failure
     volumes:
@@ -69,10 +69,10 @@ services:
   charon-validator-3:
     build:
       context: charon-validator
-      dockerfile: Dockerfile.teku
+      dockerfile: Dockerfile.lodestar
       args:
         UPSTREAM_VERSION: v0.17.2
-        VALIDATOR_CLIENT_VERSION: 23.11.0
+        VALIDATOR_CLIENT_VERSION: v1.15.1
         CLUSTER_ID: 3
     restart: on-failure
     volumes:
@@ -102,10 +102,10 @@ services:
   charon-validator-4:
     build:
       context: charon-validator
-      dockerfile: Dockerfile.teku
+      dockerfile: Dockerfile.lodestar
       args:
         UPSTREAM_VERSION: v0.17.2
-        VALIDATOR_CLIENT_VERSION: 23.11.0
+        VALIDATOR_CLIENT_VERSION: v1.15.1
         CLUSTER_ID: 4
     restart: on-failure
     volumes:
@@ -135,10 +135,10 @@ services:
   charon-validator-5:
     build:
       context: charon-validator
-      dockerfile: Dockerfile.teku
+      dockerfile: Dockerfile.lodestar
       args:
         UPSTREAM_VERSION: v0.17.2
-        VALIDATOR_CLIENT_VERSION: 23.11.0
+        VALIDATOR_CLIENT_VERSION: v1.15.1
         CLUSTER_ID: 5
     restart: on-failure
     volumes:


### PR DESCRIPTION
Replacing Teku validator client with Lodestar version v1.15.1

Also, `LODESTAR_VERSION` env variable was replaced by `VALIDATOR_CLIENT_VERSION`. Previous code resulted in latest upstream version being downloaded from official repo (instead of version defined in compose file
